### PR TITLE
Terraform 0.12 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ module "s3-static-website" {
   source  = "conortm/s3-static-website/aws"
 
   domain_name = "www.my-aws-s3-static-website.com"
-  redirects   = ["my-aws-s3-static-website.com"]
+  redirects   = {
+      "my-static-website" : "my-aws-s3-static-website.com"
+  }
   secret      = "SOME_SECRET_MANAGED_OUTSIDE_OF_VERSION_CONTROL"
   cert_arn    = "ARN_OF_SSL_CERTIFICATE"
   zone_id     = "HOSTED_ZONE_ID"

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,7 @@ variable "secret" {
 
 variable "tags" {
   description = "A mapping of tags to assign to each resource"
-  type = map(string)
+  type        = map(string)
   default     = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,11 @@
 variable "cert_arn" {
   description = "ARN of the SSL Certificate to use for the Cloudfront Distribution"
-  type        = "string"
+  type        = string
 }
 
 variable "domain_name" {
   description = "Domain name for the website (i.e. www.example.com)"
-  type        = "string"
+  type        = string
 }
 
 variable "public_dir" {
@@ -15,20 +15,21 @@ variable "public_dir" {
 
 variable "redirects" {
   description = "A list of domains that should redirect to domain_name (i.e. for redirecting naked domain to www-version)"
-  default     = []
+  type        = map(string)
 }
 
 variable "secret" {
   description = "A secret string between CloudFront and S3 to control access"
-  type        = "string"
+  type        = string
 }
 
 variable "tags" {
   description = "A mapping of tags to assign to each resource"
+  type = map(string)
   default     = {}
 }
 
 variable "zone_id" {
   description = "ID of the Route 53 Hosted Zone in which to create an alias record"
-  type        = "string"
+  type        = string
 }


### PR DESCRIPTION
Adds variable types to the variables.tf, as well as for loops instead of count for resources. This module still worked under 0.12, but I think it's better to update it using the new constructs. 

A lot of formatting fixes as well, simply running `terraform fmt` changed quite a bit, so there might seem like quite a few more changes than there really are.