### PR TITLE
feat: add lambda functions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
-  public_dir_with_leading_slash = "${length(var.public_dir) > 0 ? "/${var.public_dir}" : ""}"
-  static_website_routing_rules = <<EOF
+  public_dir_with_leading_slash = length(var.public_dir) > 0 ? "/${var.public_dir}" : ""
+  static_website_routing_rules  = <<EOF
 [{
     "Condition": {
         "KeyPrefixEquals": "${var.public_dir}/${var.public_dir}/"
@@ -16,16 +16,16 @@ EOF
 }
 
 resource "aws_s3_bucket" "static_website" {
-  bucket = "${var.domain_name}"
+  bucket = var.domain_name
 
   website {
     index_document = "index.html"
     error_document = "error.html"
 
-    routing_rules = "${length(var.public_dir) > 0 ? local.static_website_routing_rules : ""}"
+    routing_rules = length(var.public_dir) > 0 ? local.static_website_routing_rules : ""
   }
 
-  tags = "${merge(map("Name", "${var.domain_name}-static_website"), var.tags)}"
+  tags = merge(tomap("Name", "${var.domain_name}-static_website"), var.tags)
 }
 
 data "aws_iam_policy_document" "static_website_read_with_secret" {
@@ -40,16 +40,16 @@ data "aws_iam_policy_document" "static_website_read_with_secret" {
     }
 
     condition {
-      test = "StringEquals"
+      test     = "StringEquals"
       variable = "aws:UserAgent"
-      values = ["${var.secret}"]
+      values   = ["${var.secret}"]
     }
   }
 }
 
 resource "aws_s3_bucket_policy" "static_website_read_with_secret" {
-  bucket = "${aws_s3_bucket.static_website.id}"
-  policy = "${data.aws_iam_policy_document.static_website_read_with_secret.json}"
+  bucket = aws_s3_bucket.static_website.id
+  policy = data.aws_iam_policy_document.static_website_read_with_secret.json
 }
 
 locals {
@@ -58,20 +58,20 @@ locals {
 
 resource "aws_cloudfront_distribution" "cdn" {
   origin {
-    domain_name = "${aws_s3_bucket.static_website.website_endpoint}"
-    origin_path = "${local.public_dir_with_leading_slash}"
-    origin_id   = "${local.s3_origin_id}"
+    domain_name = aws_s3_bucket.static_website.website_endpoint
+    origin_path = local.public_dir_with_leading_slash
+    origin_id   = local.s3_origin_id
 
     custom_origin_config {
-      http_port               = 80
-      https_port              = 443
-      origin_protocol_policy  = "http-only"
-      origin_ssl_protocols    = ["TLSv1.2", "TLSv1.1", "TLSv1"]
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2", "TLSv1.1", "TLSv1"]
     }
 
     custom_header {
       name  = "User-Agent"
-      value = "${var.secret}"
+      value = var.secret
     }
   }
 
@@ -82,19 +82,19 @@ resource "aws_cloudfront_distribution" "cdn" {
   aliases             = ["${var.domain_name}"]
 
   custom_error_response {
-    error_code          = 403
-    response_page_path  = "/error.html"
-    response_code       = 404
+    error_code         = 403
+    response_page_path = "/error.html"
+    response_code      = 404
   }
 
   custom_error_response {
-    error_code          = 404
-    response_page_path  = "/error.html"
-    response_code       = 404
+    error_code         = 404
+    response_page_path = "/error.html"
+    response_code      = 404
   }
 
   default_cache_behavior {
-    target_origin_id = "${local.s3_origin_id}"
+    target_origin_id = local.s3_origin_id
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
 
@@ -116,52 +116,52 @@ resource "aws_cloudfront_distribution" "cdn" {
   }
 
   viewer_certificate {
-    acm_certificate_arn       = "${var.cert_arn}"
-    ssl_support_method        = "sni-only"
-    minimum_protocol_version  = "TLSv1.1_2016"
+    acm_certificate_arn      = var.cert_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.1_2016"
   }
 
-  tags = "${merge(map("Name", "${var.domain_name}-cdn"), var.tags)}"
+  tags = merge(tomap("Name", "${var.domain_name}-cdn"), var.tags)
 }
 
 resource "aws_route53_record" "alias" {
-  count = "${length(var.zone_id) > 0 ? 1 : 0}"
+  count = length(var.zone_id) > 0 ? 1 : 0
 
-  zone_id = "${var.zone_id}"
-  name    = "${var.domain_name}"
+  zone_id = var.zone_id
+  name    = var.domain_name
   type    = "A"
 
   alias {
-    name                    = "${aws_cloudfront_distribution.cdn.domain_name}"
-    zone_id                 = "${aws_cloudfront_distribution.cdn.hosted_zone_id}"
-    evaluate_target_health  = false
+    name                   = aws_cloudfront_distribution.cdn.domain_name
+    zone_id                = aws_cloudfront_distribution.cdn.hosted_zone_id
+    evaluate_target_health = false
   }
 }
 
 resource "aws_s3_bucket" "redirect" {
-  count = "${length(var.redirects)}"
+  count = length(var.redirects)
 
-  bucket = "${element(var.redirects, count.index)}"
+  bucket = element(var.redirects, count.index)
 
   website {
     redirect_all_requests_to = "https://${var.domain_name}"
   }
 
-  tags = "${merge(map("Name", "${element(var.redirects, count.index)}-redirect"), var.tags)}"
+  tags = merge(tomap("Name", "${element(var.redirects, count.index)}-redirect"), var.tags)
 }
 
 resource "aws_cloudfront_distribution" "redirect" {
-  count = "${length(var.redirects)}"
+  count = length(var.redirects)
 
   origin {
-    domain_name = "${element(aws_s3_bucket.redirect.*.website_endpoint, count.index)}"
+    domain_name = element(aws_s3_bucket.redirect.*.website_endpoint, count.index)
     origin_id   = "cloudfront-distribution-origin-${element(var.redirects, count.index)}.s3.amazonaws.com"
 
     custom_origin_config {
-      http_port               = 80
-      https_port              = 443
-      origin_protocol_policy  = "http-only"
-      origin_ssl_protocols    = ["TLSv1.2", "TLSv1.1", "TLSv1"]
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2", "TLSv1.1", "TLSv1"]
     }
   }
 
@@ -193,25 +193,25 @@ resource "aws_cloudfront_distribution" "redirect" {
   }
 
   viewer_certificate {
-    acm_certificate_arn       = "${var.cert_arn}"
-    ssl_support_method        = "sni-only"
-    minimum_protocol_version  = "TLSv1.1_2016"
+    acm_certificate_arn      = var.cert_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.1_2016"
   }
 
-  tags = "${merge(map("Name", "${element(var.redirects, count.index)}-cdn_redirect"), var.tags)}"
+  tags = merge(tomap("Name", "${element(var.redirects, count.index)}-cdn_redirect"), var.tags)
 }
 
 resource "aws_route53_record" "redirect" {
-  count = "${length(var.zone_id) > 0 ? length(var.redirects) : 0}"
+  count = length(var.zone_id) > 0 ? length(var.redirects) : 0
 
-  zone_id = "${var.zone_id}"
+  zone_id = var.zone_id
   # Work-around (see: https://github.com/hashicorp/terraform/issues/11210)
-  name    = "${length(var.redirects) > 0 ? element(concat(var.redirects, list("")), count.index): ""}"
-  type    = "A"
+  name = length(var.redirects) > 0 ? element(concat(var.redirects, list("")), count.index) : ""
+  type = "A"
 
   alias {
-    name                    = "${element(aws_cloudfront_distribution.redirect.*.domain_name, count.index)}"
-    zone_id                 = "${element(aws_cloudfront_distribution.redirect.*.hosted_zone_id, count.index)}"
-    evaluate_target_health  = false
+    name                   = element(aws_cloudfront_distribution.redirect.*.domain_name, count.index)
+    zone_id                = element(aws_cloudfront_distribution.redirect.*.hosted_zone_id, count.index)
+    evaluate_target_health = false
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "aws_s3_bucket" "static_website" {
     routing_rules = length(var.public_dir) > 0 ? local.static_website_routing_rules : ""
   }
 
-  tags = merge(tomap("Name", "${var.domain_name}-static_website"), var.tags)
+  tags = merge(tomap({ "Name" = "${var.domain_name}-static_website" }), var.tags)
 }
 
 data "aws_iam_policy_document" "static_website_read_with_secret" {
@@ -121,7 +121,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     minimum_protocol_version = "TLSv1.1_2016"
   }
 
-  tags = merge(tomap("Name", "${var.domain_name}-cdn"), var.tags)
+  tags = merge(tomap({ "Name" = "${var.domain_name}-cdn" }), var.tags)
 }
 
 resource "aws_route53_record" "alias" {
@@ -147,7 +147,7 @@ resource "aws_s3_bucket" "redirect" {
     redirect_all_requests_to = "https://${var.domain_name}"
   }
 
-  tags = merge(tomap("Name", "${element(var.redirects, count.index)}-redirect"), var.tags)
+  tags = merge(tomap({ "Name" = "${element(var.redirects, count.index)}-redirect" }), var.tags)
 }
 
 resource "aws_cloudfront_distribution" "redirect" {
@@ -198,7 +198,7 @@ resource "aws_cloudfront_distribution" "redirect" {
     minimum_protocol_version = "TLSv1.1_2016"
   }
 
-  tags = merge(tomap("Name", "${element(var.redirects, count.index)}-cdn_redirect"), var.tags)
+  tags = merge(tomap({ "Name" = "${element(var.redirects, count.index)}-cdn_redirect" }), var.tags)
 }
 
 resource "aws_route53_record" "redirect" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "domain_name" {
 
 variable "public_dir" {
   description = "Directory in S3 Bucket from which to serve public files (no leading or trailing slashes)"
-  default     = public
+  default     = "public"
 }
 
 variable "redirects" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,16 @@
 variable "cert_arn" {
   description = "ARN of the SSL Certificate to use for the Cloudfront Distribution"
-  type        = "string"
+  type        = string
 }
 
 variable "domain_name" {
   description = "Domain name for the website (i.e. www.example.com)"
-  type        = "string"
+  type        = string
 }
 
 variable "public_dir" {
   description = "Directory in S3 Bucket from which to serve public files (no leading or trailing slashes)"
-  default     = "public"
+  default     = public
 }
 
 variable "redirects" {
@@ -20,7 +20,7 @@ variable "redirects" {
 
 variable "secret" {
   description = "A secret string between CloudFront and S3 to control access"
-  type        = "string"
+  type        = string
 }
 
 variable "tags" {
@@ -30,5 +30,5 @@ variable "tags" {
 
 variable "zone_id" {
   description = "ID of the Route 53 Hosted Zone in which to create an alias record"
-  type        = "string"
+  type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,3 +32,15 @@ variable "zone_id" {
   description = "ID of the Route 53 Hosted Zone in which to create an alias record"
   type        = string
 }
+
+variable "lambda_origin_request_arn" {
+  description = "Lambda edge function arn to bind to origin-request"
+  type        = string 
+  default     = ""
+}
+
+variable "lambda_origin_response_arn" {
+  description = "Lambda edge function arn to bind to origin-response"
+  type        = string 
+  default     = ""
+}


### PR DESCRIPTION
Add two variables for origin-request and origin-response lambda arns.
Add them to the default cloudfront distribution.
Add new restrictions on bucket to to deny anything that isn't the secret string coming from cloudfront to S3 bucket